### PR TITLE
kenlm會當訓練較細的文本

### DIFF
--- a/臺灣言語工具/語言模型/KenLM語言模型訓練.py
+++ b/臺灣言語工具/語言模型/KenLM語言模型訓練.py
@@ -39,6 +39,7 @@ class KenLM語言模型訓練(程式腳本):
                     [
                         self.訓練指令,
                         '-o', str(連紲詞長度),
+                        '--discount_fallback',
                         '-S', 使用記憶體量,
                         '-T', '/tmp',
                     ],


### PR DESCRIPTION
https://github.com/sih4sing5hong5/tai5-uan5_gian5-gi2_hok8-bu7/issues/102

語料傷細定定拄著error，照伊的建議加--discount_fallback

/home/Ihc/git/tai5-uan5_gian5-gi2_kang1-ku7/外部程式/mosesdecoder/lm/builder/adjust_counts.cc:53
in void
lm::builder::{anonymous}::StatCollector::CalculateDiscounts(const lm::builder::DiscountConfig&)
threw BadDiscountException because `s.n[j] == 0'.
Could not calculate Kneser-Ney discounts for 2-grams with adjusted count
2 because we didn't observe any 2-grams with adjusted count 1; Is this
small or artificial data?
Try deduplicating the input.  To override this error for e.g. a
class-based model, rerun with --discount_fallback