### PR TITLE
分詞符號濫佇語句內底，會無法度分開

### DIFF
--- a/臺灣言語工具/解析整理/拆文分析器.py
+++ b/臺灣言語工具/解析整理/拆文分析器.py
@@ -395,8 +395,11 @@ class 拆文分析器:
 
     @classmethod
     def 分詞詞物件(cls, 分詞):
+        print('xx',分詞)
         程式掠漏.毋是字串都毋著(分詞)
         if 分詞 == '':
+            return cls.建立詞物件(分詞)
+        if 分詞 == 分型音符號:
             return cls.建立詞物件(分詞)
         切開結果 = 分詞.split(分型音符號)
         if len(切開結果) == 2:

--- a/試驗/解析整理/Test拆文分析器分詞單元試驗.py
+++ b/試驗/解析整理/Test拆文分析器分詞單元試驗.py
@@ -108,10 +108,6 @@ class 拆文分析器分詞單元試驗(unittest.TestCase):
         詞物件 = 拆文分析器.分詞詞物件(分詞)
         self.assertEqual(len(詞物件.內底字), 0)
 
-    def test_分詞詞有分詞無半字(self):
-        分詞 = '｜'
-        self.assertRaises(解析錯誤, 拆文分析器.分詞詞物件, 分詞)
-
     def test_分詞詞無分型音(self):
         分詞 = '美麗'
         詞物件 = 拆文分析器.分詞詞物件(分詞)
@@ -129,6 +125,13 @@ class 拆文分析器分詞單元試驗(unittest.TestCase):
         self.assertEqual(len(詞物件.內底字), 1)
         self.assertEqual(詞物件.內底字[0].型, 型)
         self.assertEqual(詞物件.內底字[0].音, 音)
+
+    def test_分詞詞有分詞無半字(self):
+        分詞 = '｜'
+        詞物件 = 拆文分析器.分詞詞物件(分詞)
+        self.assertEqual(len(詞物件.內底字), 1)
+        self.assertEqual(詞物件.內底字[0].型, '｜')
+        self.assertEqual(詞物件.內底字[0].音, 無音)
 
     def test_分詞全是分詞符號(self):
         詞物件 = 拆文分析器.分詞詞物件('｜｜｜')
@@ -153,6 +156,18 @@ class 拆文分析器分詞單元試驗(unittest.TestCase):
         self.assertEqual(len(組物件.內底詞), 2)
         self.assertEqual(組物件.內底詞[1].內底字[0].型, '｜')
         self.assertEqual(組物件.內底詞[1].內底字[0].音, '｜')
+
+    def test_分詞內有獨立的分詞符號(self):
+        字物件陣列 = 拆文分析器.分詞組物件('｜ ＝ 安 姑 ＝ ｜ ＝ ＝ 表 小 弟').篩出字物件()
+        self.assertEqual(len(字物件陣列), 11)
+        self.assertEqual(字物件陣列[0].型, '｜')
+        self.assertEqual(字物件陣列[0].音, 無音)
+        self.assertEqual(字物件陣列[1].型, '＝')
+        self.assertEqual(字物件陣列[1].音, 無音)
+        self.assertEqual(字物件陣列[5].型, '｜')
+        self.assertEqual(字物件陣列[5].音, 無音)
+        self.assertEqual(字物件陣列[11].型, '弟')
+        self.assertEqual(字物件陣列[11].音, 無音)
 
     def test_分詞組集句章孤字(self):
         分詞 = '𪜶｜in1'


### PR DESCRIPTION
原本想欲處理`｜ ＝ 安 姑 ＝ ｜ ＝ ＝ 表 小 弟`
毋過佮這馬的設定有衝突
```
xx ｜
xx ＝
xx 安
xx 姑
xx ＝ ｜ ＝
```